### PR TITLE
Analog output function issue fix

### DIFF
--- a/docs/analog_io.md
+++ b/docs/analog_io.md
@@ -36,7 +36,7 @@ analogWrite(pin, 0.5);
 ## tone(pin, frequency[, duration[, duty]])
 
 * __`pin`__ `{number}` Pin number.
-* __`frequency`__ `{number}` Frequency in Hz. Default is `490`Hz.
+* __`frequency`__ `{number}` Frequency in Hz. Default is `261.6`Hz which is the frequency of C4
 * __`duration`__ `{number}` Duration in milliseconds. Default is 0.
 * __`duty`__ `{number}` Duty cycle between 0 and 1.
 

--- a/src/modules/pwm/module_pwm.c
+++ b/src/modules/pwm/module_pwm.c
@@ -36,8 +36,13 @@ JERRYXX_FUN(pwm_ctor_fn) {
   double frequency = JERRYXX_GET_ARG_NUMBER_OPT(1, PWM_DEFAULT_FREQUENCY);
   double duty = JERRYXX_GET_ARG_NUMBER_OPT(2, PWM_DEFAULT_DUTY);
   jerryxx_set_property_number(JERRYXX_GET_THIS, MSTR_PWM_PIN, pin);
-  pwm_setup(pin, frequency, duty);
-  return jerry_create_undefined();
+  if (pwm_setup(pin, frequency, duty) != -1) {
+    return jerry_create_undefined();
+  } else {
+    char errmsg[255];
+    sprintf(errmsg, "\"%d\" This pin can't be used for PWM", pin);
+    return jerry_create_error(JERRY_ERROR_TYPE, (const jerry_char_t *) errmsg);
+  }
 }
 
 JERRYXX_FUN(pwm_start_fn) {

--- a/targets/boards/kameleon-core/src/pwm.c
+++ b/targets/boards/kameleon-core/src/pwm.c
@@ -24,11 +24,11 @@
 
 extern void HAL_TIM_MspPostInit(TIM_HandleTypeDef *htim);
 
-static void tim1_pwm_setup(uint32_t, uint32_t, uint32_t);
-static void tim2_pwm_setup(uint32_t, uint32_t, uint32_t);
-static void tim3_pwm_setup(uint32_t, uint32_t, uint32_t);
-static void tim4_pwm_setup(uint32_t, uint32_t, uint32_t);
-static void tim5_pwm_setup(uint32_t, uint32_t, uint32_t);
+static void tim1_pwm_setup(uint32_t, uint32_t, uint32_t, uint32_t);
+static void tim2_pwm_setup(uint32_t, uint32_t, uint32_t, uint32_t);
+static void tim3_pwm_setup(uint32_t, uint32_t, uint32_t, uint32_t);
+static void tim4_pwm_setup(uint32_t, uint32_t, uint32_t, uint32_t);
+static void tim5_pwm_setup(uint32_t, uint32_t, uint32_t, uint32_t);
 
 static TIM_HandleTypeDef htim1;
 static TIM_HandleTypeDef htim2;
@@ -36,6 +36,8 @@ static TIM_HandleTypeDef htim3;
 static TIM_HandleTypeDef htim4;
 static TIM_HandleTypeDef htim5;
 
+#define PWMMAXFREQ    450000 //450kHz
+#define PWMMINFREQ    1      //1Hz
 /**
 * APB1 BUS CLOCK (48MHz max)
 * APB1 TIMER CLOCK (96MHz max)
@@ -50,7 +52,7 @@ static const struct __pwm_config {
     TIM_HandleTypeDef * handle;
     TIM_TypeDef * instance;
     uint32_t channel;
-    void (*setup)(uint32_t, uint32_t, uint32_t);
+    void (*setup)(uint32_t, uint32_t, uint32_t, uint32_t);
     HAL_StatusTypeDef (*start)(TIM_HandleTypeDef *, uint32_t);
     HAL_StatusTypeDef (*stop)(TIM_HandleTypeDef *, uint32_t);
     uint8_t bus;
@@ -61,12 +63,6 @@ static const struct __pwm_config {
    {15, GPIOB, GPIO_PIN_10, &htim2, TIM2, TIM_CHANNEL_3, tim2_pwm_setup, HAL_TIM_PWM_Start, HAL_TIM_PWM_Stop, APB1},
    {16, GPIOB, GPIO_PIN_9, &htim4, TIM4, TIM_CHANNEL_4, tim4_pwm_setup, HAL_TIM_PWM_Start, HAL_TIM_PWM_Stop, APB1},
 };
-
-/**
-* tick freq division (must be greater than or equal to 1)
-*/
-static const uint32_t tick_freq_div=4;
-
 
 /**
  * Get PWM index
@@ -96,25 +92,57 @@ static uint8_t get_pwm_index(uint8_t pin) {
 */
 static uint32_t get_tick_frequency(uint8_t n) {
   uint32_t tick_freq;
-  uint8_t bus = pwm_config[n].bus;
-
+  uint8_t bus;
+  //bus = pwm_config[n].bus;
+  bus = APB2; //Workaround, all Timer clock seems to be 96MHz.
   if (bus==APB1) {
-    tick_freq = 2 * HAL_RCC_GetPCLK1Freq();
+    tick_freq = HAL_RCC_GetPCLK1Freq();
   } else if (bus==APB2) {
-    tick_freq = 2 * HAL_RCC_GetPCLK2Freq();
+    tick_freq = HAL_RCC_GetPCLK2Freq();
   }
-  return (tick_freq / tick_freq_div);
+  return tick_freq;
 }
 
 /**
 */
-static void tim1_pwm_setup(uint32_t channel, uint32_t arr, uint32_t pulse) {
+static uint32_t get_tick_prescaler(uint8_t n, double frequency) {
+  uint32_t prescaler;
+  uint8_t bus;
+  //bus = pwm_config[n].bus;
+  bus = APB2; //Workaround, all Timer clock seems to be 96MHz.
+  if (bus == APB1) { //48MHz
+    if (frequency > 700)
+      prescaler = 1;
+    else if (frequency > 100)
+      prescaler = 8;
+    else if (frequency > 15)
+      prescaler = 64;
+    else
+      prescaler = 1024;
+  } else if (bus == APB2) { //96MHz
+    if (frequency > 1500)
+      prescaler = 1;
+    else if (frequency > 200)
+      prescaler = 8;
+    else if (frequency > 25)
+      prescaler = 64;
+    else if (frequency > 1.5)
+      prescaler = 1024;
+    else
+      prescaler = 2048;
+  }
+  return prescaler;
+}
+
+/**
+*/
+static void tim1_pwm_setup(uint32_t channel, uint32_t prescaler, uint32_t arr, uint32_t pulse) {
   TIM_MasterConfigTypeDef sMasterConfig;
   TIM_OC_InitTypeDef sConfigOC;
   TIM_BreakDeadTimeConfigTypeDef sBreakDeadTimeConfig;
 
   htim1.Instance = TIM1;
-  htim1.Init.Prescaler = tick_freq_div - 1;
+  htim1.Init.Prescaler = prescaler - 1;
   htim1.Init.CounterMode = TIM_COUNTERMODE_UP;
   htim1.Init.Period = arr;
   htim1.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
@@ -138,7 +166,7 @@ static void tim1_pwm_setup(uint32_t channel, uint32_t arr, uint32_t pulse) {
   sConfigOC.OCFastMode = TIM_OCFAST_DISABLE;
   sConfigOC.OCIdleState = TIM_OCIDLESTATE_RESET;
   sConfigOC.OCNIdleState = TIM_OCNIDLESTATE_RESET;
-  if (HAL_TIM_PWM_ConfigChannel(&htim1, &sConfigOC, TIM_CHANNEL_3) != HAL_OK)
+  if (HAL_TIM_PWM_ConfigChannel(&htim1, &sConfigOC, channel) != HAL_OK)
   {
     _Error_Handler(__FILE__, __LINE__);
   }
@@ -160,12 +188,12 @@ static void tim1_pwm_setup(uint32_t channel, uint32_t arr, uint32_t pulse) {
 
 /**
 */
-static void tim2_pwm_setup(uint32_t channel, uint32_t arr, uint32_t pulse) {
+static void tim2_pwm_setup(uint32_t channel, uint32_t prescaler, uint32_t arr, uint32_t pulse) {
   TIM_MasterConfigTypeDef sMasterConfig;
   TIM_OC_InitTypeDef sConfigOC;
 
   htim2.Instance = TIM2;
-  htim2.Init.Prescaler = tick_freq_div - 1;
+  htim2.Init.Prescaler = prescaler - 1;
   htim2.Init.CounterMode = TIM_COUNTERMODE_UP;
   htim2.Init.Period = arr;
   htim2.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
@@ -195,12 +223,12 @@ static void tim2_pwm_setup(uint32_t channel, uint32_t arr, uint32_t pulse) {
 
 /**
 */
-static void tim3_pwm_setup(uint32_t channel, uint32_t arr, uint32_t pulse) {
+static void tim3_pwm_setup(uint32_t channel, uint32_t prescaler, uint32_t arr, uint32_t pulse) {
   TIM_MasterConfigTypeDef sMasterConfig;
   TIM_OC_InitTypeDef sConfigOC;
 
   htim3.Instance = TIM3;
-  htim3.Init.Prescaler = tick_freq_div - 1;
+  htim3.Init.Prescaler = prescaler - 1;
   htim3.Init.CounterMode = TIM_COUNTERMODE_UP;
   htim3.Init.Period = arr;
   htim3.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
@@ -231,12 +259,12 @@ static void tim3_pwm_setup(uint32_t channel, uint32_t arr, uint32_t pulse) {
 
 /**
 */
-static void tim4_pwm_setup(uint32_t channel, uint32_t arr, uint32_t pulse) {
+static void tim4_pwm_setup(uint32_t channel, uint32_t prescaler, uint32_t arr, uint32_t pulse) {
   TIM_MasterConfigTypeDef sMasterConfig;
   TIM_OC_InitTypeDef sConfigOC;
 
   htim4.Instance = TIM4;
-  htim4.Init.Prescaler = tick_freq_div - 1;
+  htim4.Init.Prescaler = prescaler - 1;
   htim4.Init.CounterMode = TIM_COUNTERMODE_UP;
   htim4.Init.Period = arr;
   htim4.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
@@ -266,12 +294,12 @@ static void tim4_pwm_setup(uint32_t channel, uint32_t arr, uint32_t pulse) {
 
 /**
 */
-static void tim5_pwm_setup(uint32_t channel, uint32_t arr, uint32_t pulse) {
+static void tim5_pwm_setup(uint32_t channel, uint32_t prescaler, uint32_t arr, uint32_t pulse) {
   TIM_MasterConfigTypeDef sMasterConfig;
   TIM_OC_InitTypeDef sConfigOC;
 
   htim5.Instance = TIM5;
-  htim5.Init.Prescaler = tick_freq_div - 1;;
+  htim5.Init.Prescaler = prescaler - 1;
   htim5.Init.CounterMode = TIM_COUNTERMODE_UP;
   htim5.Init.Period = arr;
   htim5.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
@@ -291,7 +319,7 @@ static void tim5_pwm_setup(uint32_t channel, uint32_t arr, uint32_t pulse) {
   sConfigOC.Pulse = pulse;
   sConfigOC.OCPolarity = TIM_OCPOLARITY_HIGH;
   sConfigOC.OCFastMode = TIM_OCFAST_DISABLE;
-  if (HAL_TIM_PWM_ConfigChannel(&htim5, &sConfigOC, TIM_CHANNEL_1) != HAL_OK)
+  if (HAL_TIM_PWM_ConfigChannel(&htim5, &sConfigOC, channel) != HAL_OK)
   {
     _Error_Handler(__FILE__, __LINE__);
   }
@@ -302,17 +330,29 @@ static void tim5_pwm_setup(uint32_t channel, uint32_t arr, uint32_t pulse) {
 /**
  * return Returns 0 on success or -1 on failure.
 */
+
 int pwm_setup(uint8_t pin, double frequency, double duty) {
-  uint32_t tick_freq, ch, arr, pulse;
+  uint32_t tick_freq, ch, prescaler, arr, pulse;
+  uint8_t pduty = duty * 100;
   uint8_t n = get_pwm_index(pin);
   if (n == 0xFF) //Not a index of PWM pin
     return -1;
 
+  //Mix Max check
+  if (pduty > 100)
+    pduty = 100;
+  if (frequency > PWMMAXFREQ) //Max
+    frequency = PWMMAXFREQ;
+  else if (frequency < PWMMINFREQ) //Min
+    frequency = PWMMINFREQ;
+
   tick_freq = get_tick_frequency(n);
+  prescaler = get_tick_prescaler(n, frequency);
   ch = pwm_config[n].channel;
-  arr = (uint32_t)(tick_freq / frequency + 0.5f) - 1;
-  pulse = (uint32_t)(duty * (arr + 1) + 0.5f);
-  pwm_config[n].setup(ch, arr, pulse);
+  arr = (uint32_t)(tick_freq / prescaler / frequency - 1);
+  pulse = (uint32_t)((pduty * arr)/100);
+
+  pwm_config[n].setup(ch, prescaler, arr, pulse);
 
   return 0;
 }
@@ -339,7 +379,7 @@ double pwm_get_frequency(uint8_t pin) {
   uint8_t n = get_pwm_index(pin);
   if (n != 0xFF) { //PWM pin index
     uint32_t tick_freq = get_tick_frequency(n);
-    return (double)tick_freq/(__HAL_TIM_GET_AUTORELOAD(pwm_config[n].handle)+1);
+    return (double)tick_freq/(pwm_config[n].handle->Init.Prescaler + 1)/(__HAL_TIM_GET_AUTORELOAD(pwm_config[n].handle) + 1);
   }
 }
 
@@ -369,16 +409,9 @@ void pwm_set_duty(uint8_t pin, double duty) {
 */
 void pwm_set_frequency(uint8_t pin, double frequency) {
   double previous_duty = pwm_get_duty(pin);
-
   uint8_t n = get_pwm_index(pin);
-  if (n != 0xFF) { //PWM pin index
-    uint32_t arr = (uint32_t)(get_tick_frequency(n)/frequency + 0.5f) - 1;
-    uint32_t pulse = (uint32_t)(previous_duty * (arr + 1) + 0.5f);
-
-    /* The previous duty ratio must be hold up regardless of changing frequency */
-    __HAL_TIM_SET_COMPARE(pwm_config[n].handle, pwm_config[n].channel, pulse);
-    __HAL_TIM_SET_AUTORELOAD(pwm_config[n].handle, arr);
-
+  /* The previous duty ratio must be hold up regardless of changing frequency */
+  if (pwm_setup(pin, frequency, previous_duty) != -1) {
     /* The counter value must be reset for not being over the arr value. */
     __HAL_TIM_SET_COUNTER(pwm_config[n].handle, 0);
   }

--- a/targets/shared/drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_tim.c
+++ b/targets/shared/drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_tim.c
@@ -230,7 +230,7 @@ HAL_StatusTypeDef HAL_TIM_Base_Init(TIM_HandleTypeDef *htim)
   htim->State= HAL_TIM_STATE_BUSY;
   
   /* Set the Time Base configuration */
-  TIM_Base_SetConfig(htim->Instance, &htim->Init); 
+  TIM_Base_SetConfig(htim->Instance, &htim->Init);
   
   /* Initialize the TIM state*/
   htim->State= HAL_TIM_STATE_READY;
@@ -1110,7 +1110,7 @@ HAL_StatusTypeDef HAL_TIM_PWM_Start(TIM_HandleTypeDef *htim, uint32_t Channel)
   /* Enable the Capture compare channel */
   TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
   
-  if(IS_TIM_ADVANCED_INSTANCE(htim->Instance) != RESET)  
+  if(IS_TIM_ADVANCED_INSTANCE(htim->Instance) != RESET)
   {
     /* Enable the main output */
     __HAL_TIM_MOE_ENABLE(htim);
@@ -4486,14 +4486,14 @@ void TIM_Base_SetConfig(TIM_TypeDef *TIMx, TIM_Base_InitTypeDef *Structure)
   tmpcr1 = TIMx->CR1;
   
   /* Set TIM Time Base Unit parameters ---------------------------------------*/
-  if(IS_TIM_CC3_INSTANCE(TIMx) != RESET)   
+  if(IS_TIM_CC3_INSTANCE(TIMx) != RESET)
   {
     /* Select the Counter Mode */
     tmpcr1 &= ~(TIM_CR1_DIR | TIM_CR1_CMS);
     tmpcr1 |= Structure->CounterMode;
   }
  
-  if(IS_TIM_CC1_INSTANCE(TIMx) != RESET)  
+  if(IS_TIM_CC1_INSTANCE(TIMx) != RESET)
   {
     /* Set the clock division */
     tmpcr1 &= ~TIM_CR1_CKD;
@@ -4503,12 +4503,12 @@ void TIM_Base_SetConfig(TIM_TypeDef *TIMx, TIM_Base_InitTypeDef *Structure)
   TIMx->CR1 = tmpcr1;
 
   /* Set the Auto-reload value */
-  TIMx->ARR = (uint32_t)Structure->Period ;
+  TIMx->ARR = (uint32_t)Structure->Period;
  
   /* Set the Prescaler value */
   TIMx->PSC = (uint32_t)Structure->Prescaler;
-    
-  if(IS_TIM_ADVANCED_INSTANCE(TIMx) != RESET)  
+
+  if(IS_TIM_ADVANCED_INSTANCE(TIMx) != RESET)
   {
     /* Set the Repetition Counter value */
     TIMx->RCR = Structure->RepetitionCounter;


### PR DESCRIPTION
 Timer frequency setting function is updated.
 PWM min/max frequency is set
  - Min frequency is 1Hz
  - Max frequency is 450kHz
 The default frequency of tune function is 261.6Hz. Document is updated.

Below issues are fixed.
 - Issue #78 is fixed
 - Issue #79 is fixed
 - Issue #80 is fixed
 - Issue #81 is fixed