### PR TITLE
SPI last bit bug fix

### DIFF
--- a/targets/boards/kameleon-core/src/stm32f4xx_hal_msp.c
+++ b/targets/boards/kameleon-core/src/stm32f4xx_hal_msp.c
@@ -138,7 +138,7 @@ void HAL_SPI_MspInit(SPI_HandleTypeDef* hspi) {
     GPIO_InitStruct.Pin = GPIO_PIN_5|GPIO_PIN_6|GPIO_PIN_7;
     GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
     GPIO_InitStruct.Pull = GPIO_NOPULL;
-    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
     GPIO_InitStruct.Alternate = GPIO_AF5_SPI1;
     HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
 
@@ -497,7 +497,7 @@ void HAL_I2C_MspInit(I2C_HandleTypeDef* hi2c) {
     GPIO_InitStruct.Pin = GPIO_PIN_6 | GPIO_PIN_7;
     GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
     GPIO_InitStruct.Pull = GPIO_PULLUP;
-    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
     GPIO_InitStruct.Alternate = GPIO_AF4_I2C1;
     HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
 


### PR DESCRIPTION
 - Resolve issue #110
 - workaround 2 : Set the IO pad configration for the SCK pin to be faster.
 - I2C0 pin settings are also changed.