### PR TITLE
Added ctrl+A/ctrl+E in repl

### DIFF
--- a/src/repl.c
+++ b/src/repl.c
@@ -219,6 +219,14 @@ static void handle_normal(char ch) {
       }
       repl_print_prompt();      
       break;
+    case 0x01: /* Ctrl + A */
+      state.position = 0;
+      set_cursor_to_position();
+      break;
+    case 0x05: /* Ctrl + E */
+      state.position = state.buffer_length;
+      set_cursor_to_position();
+      break;      
     case 0x08: /* backspace */
     case 0x7f: /* also backspace in some terminal */
       if (state.buffer_length > 0 && state.position > 0) {


### PR DESCRIPTION
Add the following functionalities in REPL.

ctrl + A : go to the beginning of the line.
ctrl + E : go to the end of the line.